### PR TITLE
rename instances of github.com to github.io in the quickstart guide

### DIFF
--- a/_posts/usage/2011-10-31-jekyll-quick-start.md
+++ b/_posts/usage/2011-10-31-jekyll-quick-start.md
@@ -25,11 +25,11 @@ If you run into a problem please consult the original [Jekyll installation docum
 You can also [create a support issue](https://github.com/plusjade/jekyll-bootstrap/issues) using GitHub Issues.
 
 Once the gem is installed you can navigate to your Jekyll-Bootstrap directory.
-If you've followed the homepage instructions this will be: USERNAME.github.com.
+If you've followed the homepage instructions this will be: USERNAME.github.io.
 Once in the directory you'll run jekyll with server support:
 
 {% highlight bash %}
-$ cd USERNAME.github.com 
+$ cd USERNAME.github.io
 $ jekyll --server
 # remember to change USERNAME to your GitHub username.
 {% endhighlight %}

--- a/assets/app.js
+++ b/assets/app.js
@@ -38,8 +38,8 @@ var Pc = {
     $("form").first().submit(function(e){
       var username = $("#github_username").val();
       $codeContainer.text(code.replace(/USERNAME/g, username));
-      $repoName.text( username + ".github.com");
-      $blogLink.text("http://" + username + ".github.com").attr("href", "http://" + username + ".github.com");
+      $repoName.text( username + ".github.io");
+      $blogLink.text("http://" + username + ".github.io").attr("href", "http://" + username + ".github.io");
       if ($.trim(username) !== ""){ 
         if (typeof mpq !== 'undefined') mpq.track("install", {"username": username });
         if (typeof _gaq !== 'undefined') _gaq.push(['_trackEvent', 'Forms', 'Input', username]);


### PR DESCRIPTION
jekyll quickstart refers to USERNAME.github.com, should be USERNAME.github.io

Looking at the quickstart, the guide recommends USERNAME.github.com
http://jekyllbootstrap.com/usage/jekyll-quick-start.html

Since April, github is transitioning github page users to use github.io.
https://github.com/blog/1452-new-github-pages-domain-github-io
